### PR TITLE
Spelling Correction and Correction of the VarCount for ActiveForest 

### DIFF
--- a/R/forest.R
+++ b/R/forest.R
@@ -729,7 +729,7 @@ Forest <- R6::R6Class(
         #' Retrieve a vector of split counts for every training set variable in the forest
         #' @param num_features Total number of features in the training set
         get_forest_split_counts = function(num_features) {
-            return(get_forest_split_counts_active_forest_cpp(self$forest_ptr, num_features))
+            return(get_overall_split_counts_active_forest_cpp(self$forest_ptr, num_features))
         }, 
         
         #' @description

--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -721,8 +721,9 @@ cpp11::writable::integers get_tree_split_counts_active_forest_cpp(cpp11::externa
     StochTree::Tree* tree = active_forest->GetTree(tree_num);
     std::vector<int32_t> split_nodes = tree->GetInternalNodes();
     for (int i = 0; i < split_nodes.size(); i++) {
-        auto split_feature = split_nodes.at(i);
-        output.at(split_feature)++;
+        auto node_id = split_nodes.at(i);
+        auto feature_split = tree->SplitIndex(node_id);
+        output.at(feature_split)++;
     }
     return output;
 }


### PR DESCRIPTION
corrected spelling error for the get_forest_split_counts function for active forests. Corrected the function to get variable count for each tree for an active forest.