### PR TITLE
Update `README.md` to incorporate `pip` installation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ Details on installation and use are available below:
 
 # Python Package
 
+## PyPI
+
 The python package is not yet on PyPI but can be installed from source using pip's [git interface](https://pip.pypa.io/en/stable/topics/vcs-support/). 
 To proceed, you will need a working version of [git](https://git-scm.com) and python 3.8 or greater (available from several sources, one of the most 
 straightforward being the [anaconda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html) suite).
 
-## Quick start
+## Development Version (Local Build)
+
+### Quick start
 
 Without worrying about virtual environments (detailed further below), `stochtree` can be installed from the command line
 
@@ -30,11 +34,11 @@ pip install numpy scipy pytest pandas scikit-learn pybind11
 pip install git+https://github.com/StochasticTree/stochtree.git
 ```
 
-## Virtual environment installation
+### Virtual environment installation
 
 Often, users prefer to manage different projects (with different package / python version requirements) in virtual environments. 
 
-### Conda
+#### Conda
 
 Conda provides a straightforward experience in managing python dependencies, avoiding version conflicts / ABI issues / etc.
 
@@ -60,7 +64,7 @@ pip install jupyterlab
 
 With these dependencies installed, you can [clone the repo](###cloning-the-repository) and run the `demo/` examples.
 
-### Venv
+#### Venv
 
 You could also use venv for environment management. First, navigate to the folder in which you usually store virtual environments 
 (i.e. `cd /path/to/envs`) and create and activate a virtual environment:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ Details on installation and use are available below:
 
 ## PyPI (`pip`)
 
-The python package is not yet on PyPI but can be installed from source using pip's [git interface](https://pip.pypa.io/en/stable/topics/vcs-support/). 
-To proceed, you will need a working version of [git](https://git-scm.com) and python 3.8 or greater (available from several sources, one of the most 
-straightforward being the [anaconda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html) suite).
+`stochtree`'s Python package can be installed from PyPI via:
+
+```
+pip install stochtree
+```
 
 ## Development Version (Local Build)
+
+The development version of stochtree can be installed from source using pip's [git interface](https://pip.pypa.io/en/stable/topics/vcs-support/).
+
+To proceed, you will need a working version of [git](https://git-scm.com) and python 3.8 or greater (available from several sources, one of the most straightforward being the [anaconda](https://docs.conda.io/projects/conda/en/stable/user-guide/install/index.html) suite).
+
 
 ### Quick start
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Details on installation and use are available below:
 
 # Python Package
 
-## PyPI
+## PyPI (`pip`)
 
 The python package is not yet on PyPI but can be installed from source using pip's [git interface](https://pip.pypa.io/en/stable/topics/vcs-support/). 
 To proceed, you will need a working version of [git](https://git-scm.com) and python 3.8 or greater (available from several sources, one of the most 


### PR DESCRIPTION
The [current version](https://github.com/StochasticTree/stochtree?tab=readme-ov-file#python-package) of `README.md` states that:

_The **python package is not yet on PyPI** but can be installed from source using pip's git interface. To proceed, you will need a working version of git and python 3.8 or greater (available from several sources, one of the most straightforward being the anaconda suite)._

This seems [incorrect](https://pypi.org/project/stochtree/) and this information might have negative impact on the package's adoption in the Python community.

This pull request fixes this, using the information presented [here](https://stochtree.ai/getting-started.html#pypi)

