### PR TITLE
Hotfix for bcf.predict without propensity scores

### DIFF
--- a/R/bcf.R
+++ b/R/bcf.R
@@ -2707,6 +2707,7 @@ predict.bcfmodel <- function(
     }
 
     # Add propensities to covariate set if necessary
+    X_combined <- X
     if (object$model_params$propensity_covariate != "none") {
         X_combined <- cbind(X, propensity)
     }


### PR DESCRIPTION
the new dataset for predictions takes X_combined, which wasn't created when propensity_covariate="none"