### PR TITLE
Fix 'undefined columns selected' in predict.bcfmodel with data frame covariates (GH 374)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,9 @@
 
 ## Bug Fixes
 
-## Documentation and Other Maintenance
+* Fixed R BCF prediction bug when covariates are passed as dataframes and an internal propensity is sampled [#374](https://github.com/StochasticTree/stochtree/issues/374)
 
+## Documentation and Other Maintenance
 
 # stochtree 0.4.2
 

--- a/R/bcf.R
+++ b/R/bcf.R
@@ -3608,16 +3608,6 @@ predict.bcfmodel <- function(
   }
 
   # Data checks
-  if (
-    (object$model_params$propensity_covariate != "none") &&
-      (is.null(propensity))
-  ) {
-    if (!object$model_params$internal_propensity_model) {
-      stop("propensity must be provided for this model")
-    }
-    # Compute propensity score using the internal bart model
-    propensity <- rowMeans(predict(object$bart_propensity_model, X)$y_hat)
-  }
   if (nrow(X) != nrow(Z)) {
     stop("X and Z must have the same number of rows")
   }
@@ -3644,9 +3634,22 @@ predict.bcfmodel <- function(
     }
   }
 
-  # Preprocess covariates
+  # Preprocess covariates before any prediction calls that depend on X being
+  # a numeric matrix (e.g. the internal propensity BART model was trained on a
+  # preprocessed matrix, so it expects a matrix, not the raw data frame)
   train_set_metadata <- object$train_set_metadata
   X <- preprocessPredictionData(X, train_set_metadata)
+
+  # Compute propensity score using the internal bart model
+  if (
+    (object$model_params$propensity_covariate != "none") &&
+      (is.null(propensity))
+  ) {
+    if (!object$model_params$internal_propensity_model) {
+      stop("propensity must be provided for this model")
+    }
+    propensity <- rowMeans(predict(object$bart_propensity_model, X)$y_hat)
+  }
 
   # Recode group IDs to integer vector (if passed as, for example, a vector of county names, etc...)
   if (!is.null(rfx_group_ids)) {

--- a/test/R/testthat/test-bcf.R
+++ b/test/R/testthat/test-bcf.R
@@ -1049,3 +1049,43 @@ test_that("Warmstart BCF reuses internal propensity model", {
   expect_equal(dim(m2$y_hat_train), c(n_train, 10))
   expect_equal(dim(m2$y_hat_test),  c(n_test, 10))
 })
+
+test_that("predict.bcfmodel works with data frame X when internal propensity model is used", {
+  skip_on_cran()
+
+  # Regression test for GitHub issue #374: predict.bcfmodel raised
+  # "undefined columns selected" when X was a data frame and the model used
+  # an internal BART propensity. The propensity BART was trained on a
+  # preprocessed matrix (column names x1, x2, ...), but predict was called
+  # with the raw data frame (column names V1, V2, ...) before preprocessing.
+  set.seed(42)
+  n <- 200
+  p_x <- 3
+  X <- matrix(runif(n * p_x, -1, 1), ncol = p_x)
+  Z <- X[, 1] + rnorm(n)
+  y <- 2 * X[, 1] + 0.5 * Z + rnorm(n)
+
+  test_inds <- 1:40
+  train_inds <- 41:n
+  X_train <- as.data.frame(X[train_inds, ])
+  X_test  <- as.data.frame(X[test_inds, ])
+  Z_train <- Z[train_inds]
+  Z_test  <- Z[test_inds]
+  y_train <- y[train_inds]
+
+  # No propensity_train provided — internal propensity model is fitted
+  bcf_model <- bcf(
+    X_train = X_train,
+    y_train = y_train,
+    Z_train = Z_train,
+    num_gfr = 5,
+    num_burnin = 0,
+    num_mcmc = 10
+  )
+
+  # Before the fix this raised "undefined columns selected"
+  expect_no_error(
+    result <- predict(bcf_model, X = X_test, Z = Z_test)
+  )
+  expect_equal(nrow(result$y_hat), length(test_inds))
+})


### PR DESCRIPTION
This fixes an R BCF prediction bug unearthed by #374 where covariates are provided as a dataframe (and thus run through the dataframe preprocessor logic) and an internal propensity model is fit. In this case, the order of operations in the `predict.bcfmodel` function is such that the internal propensity model is called **before** the preprocessor.

The fix is simple -- invert the order of these two operations. We've also added a unit test to trap this case in the future.