### PR TITLE
Fix ordinal cloglog probability transform for K>=4 categories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ## Bug Fixes
 
+* Fix ordinal cloglog probability transform for K>=4 categories [#382](https://github.com/StochasticTree/stochtree/pull/382)
+* Fixed bug that separated homogeneous parametric treatment effect term (`tau_0`) from treatment effect forest predictions (`tau(x)`), only including the latter in `tau` for BCF predictions when a parametric term is included in the model [#377](https://github.com/StochasticTree/stochtree/pull/377)
 * Fixed BCF prediction bug for prognostic function and mu(X) when adaptive coding is used and the tau(x) forest is not also requested by a prediction call [#377](https://github.com/StochasticTree/stochtree/pull/377)
 * Fixed R BCF prediction bug when covariates are passed as dataframes and an internal propensity is sampled [#374](https://github.com/StochasticTree/stochtree/issues/374)
 

--- a/R/bart.R
+++ b/R/bart.R
@@ -2854,58 +2854,18 @@ predict.bartmodel <- function(
     } else if (is_ordinal_cloglog) {
       cloglog_num_categories <- object$model_params$cloglog_num_categories
       cloglog_cutpoint_samples <- object$cloglog_cutpoint_samples
-      mean_forest_probabilities <- array(
-        NA_real_,
-        dim = c(
-          nrow(X),
-          cloglog_num_categories,
-          object$model_params$num_samples
-        )
-      )
-      for (j in 1:cloglog_num_categories) {
-        if (j == 1) {
-          mean_forest_probabilities[, j, ] <- (1 -
-            exp(
-              -exp(
-                sweep(
-                  mean_forest_predictions,
-                  2,
-                  cloglog_cutpoint_samples[j, ],
-                  "+"
-                )
-              )
-            ))
-        } else if (j == cloglog_num_categories) {
-          mean_forest_probabilities[, j, ] <- 1 -
-            apply(
-              mean_forest_probabilities[, 1:(j - 1), , drop = FALSE],
-              c(1, 3),
-              sum
-            )
-        } else {
-          mean_forest_probabilities[, j, ] <- (exp(
-            -exp(
-              sweep(
-                mean_forest_predictions,
-                2,
-                cloglog_cutpoint_samples[j - 1, ],
-                "+"
-              )
-            )
-          ) *
-            (1 -
-              exp(
-                -exp(
-                  sweep(
-                    mean_forest_predictions,
-                    2,
-                    cloglog_cutpoint_samples[j, ],
-                    "+"
-                  )
-                )
-              )))
-        }
+      n_obs_pred <- nrow(X)
+      n_samp_pred <- object$model_params$num_samples
+      mean_forest_probabilities <- array(NA_real_, dim = c(n_obs_pred, cloglog_num_categories, n_samp_pred))
+      # Sequential ordinal cloglog: P(Y=k) = prod_{j<k} S_j * (1 - S_k)
+      # S_k = exp(-exp(gamma_k + f)), running survival product across k.
+      survival_product <- matrix(1.0, nrow = n_obs_pred, ncol = n_samp_pred)
+      for (k in seq_len(cloglog_num_categories - 1)) {
+        S_k <- exp(-exp(sweep(mean_forest_predictions, 2, cloglog_cutpoint_samples[k, ], "+")))
+        mean_forest_probabilities[, k, ] <- survival_product * (1 - S_k)
+        survival_product <- survival_product * S_k
       }
+      mean_forest_probabilities[, cloglog_num_categories, ] <- survival_product
       if (predict_y_hat) {
         y_hat <- mean_forest_probabilities
       }

--- a/stochtree/bart.py
+++ b/stochtree/bart.py
@@ -2402,30 +2402,19 @@ class BARTModel:
             elif is_ordinal_cloglog:
                 cloglog_num_categories = self.cloglog_num_categories
                 cloglog_cutpoint_samples = self.cloglog_cutpoint_samples
-                n_obs = X.shape[0] if isinstance(X, np.ndarray) else X.shape[0]
+                n_obs = X.shape[0]
                 num_samples = self.num_samples
-                # Compute category probabilities: (n_obs, n_categories, n_samples)
+                # Sequential ordinal cloglog: P(Y=k) = prod_{j<k} S_j * (1 - S_k)
+                # S_k = exp(-exp(gamma_k + f)), running survival product across k.
                 mean_forest_probabilities = np.empty(
                     (n_obs, cloglog_num_categories, num_samples)
                 )
-                for j in range(cloglog_num_categories):
-                    if j == 0:
-                        # P(Y=1) = 1 - exp(-exp(eta + gamma_1))
-                        mean_forest_probabilities[:, j, :] = 1.0 - np.exp(
-                            -np.exp(mean_forest_predictions + cloglog_cutpoint_samples[j, :])
-                        )
-                    elif j == cloglog_num_categories - 1:
-                        # P(Y=K) = 1 - sum(P(Y=1),...,P(Y=K-1))
-                        mean_forest_probabilities[:, j, :] = 1.0 - np.sum(
-                            mean_forest_probabilities[:, :j, :], axis=1
-                        )
-                    else:
-                        # P(Y=j) = exp(-exp(eta + gamma_{j-1})) * (1 - exp(-exp(eta + gamma_j)))
-                        mean_forest_probabilities[:, j, :] = np.exp(
-                            -np.exp(mean_forest_predictions + cloglog_cutpoint_samples[j - 1, :])
-                        ) * (1.0 - np.exp(
-                            -np.exp(mean_forest_predictions + cloglog_cutpoint_samples[j, :])
-                        ))
+                cumulative_survival = np.ones((n_obs, num_samples))
+                for k in range(cloglog_num_categories - 1):
+                    S_k = np.exp(-np.exp(mean_forest_predictions + cloglog_cutpoint_samples[k, :]))
+                    mean_forest_probabilities[:, k, :] = cumulative_survival * (1.0 - S_k)
+                    cumulative_survival = cumulative_survival * S_k
+                mean_forest_probabilities[:, cloglog_num_categories - 1, :] = cumulative_survival
                 if predict_y_hat:
                     y_hat = mean_forest_probabilities
                 mean_forest_predictions = mean_forest_probabilities

--- a/test/R/testthat/test-predict.R
+++ b/test/R/testthat/test-predict.R
@@ -1047,6 +1047,65 @@ test_that("BART cloglog ordinal: sample posterior predictive", {
   expect_true(all(ppd1 %in% 1:n_categories))
 })
 
+test_that("BART cloglog ordinal: probability transform correctness (K=4)", {
+  skip_on_cran()
+  set.seed(123)
+  n <- 500; p <- 3; n_categories <- 4L
+  X <- matrix(runif(n * p), ncol = p)
+  beta <- rep(1 / sqrt(p), p)
+  true_lambda <- X %*% beta
+  # Balanced cutpoints: ~25% per category so all 4 are reliably observed.
+  # Unbalanced cutpoints give ~0.3% K=4 probability, often no K=4 training obs.
+  gamma_true <- c(-2.1, -1.7, -1.2)
+
+  true_probs <- matrix(0, nrow = n, ncol = n_categories)
+  surv_prod <- rep(1.0, n)
+  for (k in seq_len(n_categories - 1)) {
+    S_k <- exp(-exp(gamma_true[k] + true_lambda))
+    true_probs[, k] <- surv_prod * (1 - S_k)
+    surv_prod <- surv_prod * S_k
+  }
+  true_probs[, n_categories] <- surv_prod
+
+  y <- sapply(1:n, function(i) sample(1:n_categories, 1, prob = true_probs[i, ]))
+  n_test <- round(0.2*n); test_inds <- sort(sample(1:n, n_test, replace=FALSE))
+  train_inds <- (1:n)[!((1:n) %in% test_inds)]
+  X_train <- X[train_inds,]; X_test <- X[test_inds,]; y_train <- y[train_inds]
+  num_mcmc <- 10
+
+  bart_model <- suppressWarnings(bart(
+    X_train=X_train, y_train=y_train, num_gfr=10, num_burnin=0, num_mcmc=num_mcmc,
+    general_params=list(sample_sigma2_global=FALSE,
+      outcome_model=OutcomeModel(outcome="ordinal", link="cloglog"))))
+
+  assemble_probs <- function(f_hat, gamma_samples, K) {
+    S <- ncol(f_hat); n <- nrow(f_hat)
+    p_manual <- array(0, dim = c(n, K, S))
+    surv_prod <- matrix(1.0, nrow = n, ncol = S)
+    for (k in seq_len(K - 1)) {
+      S_k <- exp(-exp(sweep(f_hat, 2, gamma_samples[k, ], "+")))
+      p_manual[, k, ] <- surv_prod * (1 - S_k)
+      surv_prod <- surv_prod * S_k
+    }
+    p_manual[, K, ] <- surv_prod
+    p_manual
+  }
+
+  gamma_samples <- bart_model$cloglog_cutpoint_samples
+  K <- bart_model$model_params$cloglog_num_categories
+  expect_equal(K, 4L)
+
+  f_hat_r <- predict(bart_model, X=X_test, scale="linear", terms="mean_forest")
+  expect_equal(dim(f_hat_r), c(n_test, num_mcmc))
+  p_manual_r <- assemble_probs(f_hat_r, gamma_samples, K)
+  p_model_r <- predict(bart_model, X=X_test, scale="probability", terms="y_hat")
+  expect_equal(dim(p_model_r), c(n_test, n_categories, num_mcmc))
+  expect_equal(p_manual_r, p_model_r, tolerance=1e-10)
+  expect_true(all(p_model_r >= 0))
+  row_sums_r <- apply(p_model_r, c(1,3), sum)
+  expect_equal(row_sums_r, matrix(1, nrow=n_test, ncol=num_mcmc), tolerance=1e-10)
+})
+
 test_that("BART gaussian: posterior interval and contrast", {
   # Generate gaussian data
   set.seed(42)

--- a/test/python/test_predict.py
+++ b/test/python/test_predict.py
@@ -915,6 +915,62 @@ class TestPredict:
         assert ppd1.shape == (n_test, num_mcmc)
         assert set(np.unique(ppd1)).issubset(set(range(1, n_categories + 1)))
 
+    def test_bart_cloglog_ordinal_probability_transform_k4(self):
+        rng = np.random.default_rng(123)
+        n = 500; p = 3; n_categories = 4
+        X = rng.uniform(size=(n, p))
+        beta = np.full(p, 1 / np.sqrt(p))
+        true_lambda = X @ beta
+        # Balanced cutpoints: ~25% per category so all 4 are reliably observed.
+        # Unbalanced cutpoints give ~0.3% K=4 probability, often no K=4 training obs.
+        gamma_true = np.array([-2.1, -1.7, -1.2])
+
+        true_probs = np.zeros((n, n_categories))
+        surv_prod = np.ones(n)
+        for k in range(n_categories - 1):
+            S_k = np.exp(-np.exp(gamma_true[k] + true_lambda))
+            true_probs[:, k] = surv_prod * (1.0 - S_k)
+            surv_prod = surv_prod * S_k
+        true_probs[:, n_categories - 1] = surv_prod
+
+        y = np.array([rng.choice(np.arange(1, n_categories+1), p=true_probs[i,:])
+                      for i in range(n)]).astype(float)
+
+        train_inds, test_inds = train_test_split(np.arange(n), test_size=0.2, random_state=42)
+        X_train = X[train_inds, :]; X_test = X[test_inds, :]
+        y_train = y[train_inds]; n_test = X_test.shape[0]; num_mcmc = 10
+
+        bart_model = BARTModel()
+        bart_model.sample(X_train=X_train, y_train=y_train, num_gfr=10, num_burnin=0,
+            num_mcmc=num_mcmc, general_params={"sample_sigma2_global": False,
+                "outcome_model": OutcomeModel(outcome="ordinal", link="cloglog")})
+
+        def assemble_probs(f_hat, gamma_samples, K):
+            n, S = f_hat.shape
+            p_manual = np.zeros((n, K, S))
+            surv_prod = np.ones((n, S))
+            for k in range(K - 1):
+                S_k = np.exp(-np.exp(f_hat + gamma_samples[k, :]))
+                p_manual[:, k, :] = surv_prod * (1.0 - S_k)
+                surv_prod = surv_prod * S_k
+            p_manual[:, K - 1, :] = surv_prod
+            return p_manual
+
+        gamma_samples = bart_model.cloglog_cutpoint_samples  # (K-1, num_mcmc)
+        assert gamma_samples.shape == (n_categories - 1, num_mcmc)
+
+        f_hat = bart_model.predict(X=X_test, scale="linear", terms="mean_forest")
+        assert f_hat.shape == (n_test, num_mcmc)
+
+        p_manual = assemble_probs(f_hat, gamma_samples, n_categories)
+        p_model = bart_model.predict(X=X_test, scale="probability", terms="y_hat")
+        assert p_model.shape == (n_test, n_categories, num_mcmc)
+
+        np.testing.assert_allclose(p_manual, p_model, atol=1e-10)
+        assert np.all(p_model >= 0)
+        row_sums = p_model.sum(axis=1)
+        np.testing.assert_allclose(row_sums, np.ones((n_test, num_mcmc)), atol=1e-10)
+
     def test_bart_gaussian_interval_and_contrast(self):
         # Generate gaussian data
         rng = np.random.default_rng(42)


### PR DESCRIPTION
The sequential ordinal cloglog model uses $P(Y=k) = \prod_{j<k} S_j * (1-S_k)$ where $S_k = \exp(-exp(\gamma_k + f(X)))$. The old code used $S_{k-1}*(1-S_k)$ for intermediate categories (`k>=2`), which only accidentally gave the correct answer for `K=3` (where $c_1 = \gamma_1$ always), but silently produced wrong class probabilities for `K>=4`.

This PR replaces that faulty code with a running-product loop that tracks cumulative survival correctly across all K. We also add explicit unit tests for the K > 3 case in both R and Python that verify the predict output matches the manual formula and sums to 1.