### PR TITLE
Assert [[noreturn]] for Log::Fatal to avoid compiler warnings about "sometimes uninitialized"

### DIFF
--- a/include/stochtree/log.h
+++ b/include/stochtree/log.h
@@ -110,7 +110,7 @@ class Log {
     Write(LogLevel::Warning, "Warning", format, val);
     va_end(val);
   }
-  static void Fatal(const char *format, ...) {
+  [[noreturn]] static void Fatal(const char *format, ...) {
     va_list val;
     const size_t kBufSize = 1024;
     char str_buf[kBufSize];


### PR DESCRIPTION
`clang` flags e.g. here under `-Wsometimes-uninitialized`:

https://github.com/StochasticTree/stochtree/blob/5c09ac77e4125d078a9ae0ad5b29e71b33615a5c/src/sampler.cpp#L50-L56

That's because the compiler can't tell that `Log::Fatal` will always throw `std::runtime_error()`. Using `[[noreturn]]` is the standard approach here.

https://en.cppreference.com/cpp/language/attributes/noreturn
