### PR TITLE
Use <cmath> for lgamma

### DIFF
--- a/src/leaf_model.cpp
+++ b/src/leaf_model.cpp
@@ -1,6 +1,6 @@
 #include <stochtree/distributions.h>
 #include <stochtree/leaf_model.h>
-#include <boost/math/special_functions/gamma.hpp>
+#include <cmath>
 
 namespace StochTree {
 
@@ -219,11 +219,11 @@ double LogLinearVarianceLeafModel::NoSplitLogMarginalLikelihood(LogLinearVarianc
 }
 
 double LogLinearVarianceLeafModel::SuffStatLogMarginalLikelihood(LogLinearVarianceSuffStat& suff_stat, double global_variance) {
-  double prior_terms = a_ * std::log(b_) - boost::math::lgamma(a_);
+  double prior_terms = a_ * std::log(b_) - std::lgamma(a_);
   double a_term = a_ + 0.5 * suff_stat.n;
   double b_term = b_ + ((0.5 * suff_stat.weighted_sum_ei) / global_variance);
   double log_b_term = std::log(b_term);
-  double lgamma_a_term = boost::math::lgamma(a_term);
+  double lgamma_a_term = std::lgamma(a_term);
   double resid_term = a_term * log_b_term;
   double log_ml = prior_terms + lgamma_a_term - resid_term;
   return log_ml;
@@ -285,11 +285,11 @@ double CloglogOrdinalLeafModel::NoSplitLogMarginalLikelihood(CloglogOrdinalSuffS
 }
 
 double CloglogOrdinalLeafModel::SuffStatLogMarginalLikelihood(CloglogOrdinalSuffStat& suff_stat, double global_variance) {
-  double prior_terms = a_ * std::log(b_) - boost::math::lgamma(a_);
+  double prior_terms = a_ * std::log(b_) - std::lgamma(a_);
   double a_term = a_ + suff_stat.sum_Y_less_K;
   double b_term = b_ + suff_stat.other_sum;
   double log_b_term = std::log(b_term);
-  double lgamma_a_term = boost::math::lgamma(a_term);
+  double lgamma_a_term = std::lgamma(a_term);
   double resid_term = a_term * log_b_term;
   double log_ml = prior_terms + lgamma_a_term - resid_term;
   return log_ml;


### PR DESCRIPTION
This avoids any boost headaches and should be equivalent (up to machine precision).

Written by Gemini while pursuing a crash. If boost is involved in the crash, it's a bit uglier to debug vs. if `std::lgamma` is used. It's also consistent with nearby usages of `std::log()`.

OTOH, AIUI `boost::math::lgamma` is slightly more accurate, so perhaps the choice was intentional. E.g. Gemini offers the following:

---

### Where Boost is slightly more accurate:

1. **Peak ULP Error**:
   - **`boost::math::lgamma`**: Maintains a peak error strictly bounded under **$\approx 0.6 - 0.9$ ULP** across the positive real line. Boost generates its Lanczos expansion coefficients using 128-bit quad-precision arithmetic and high-degree polynomials.
   - **Standard `std::lgamma` (glibc / libm)**: Peak error typically hovers around **$1.0 - 2.0$ ULPs** in worst-case regions.

2. **Near Roots ($x \approx 1$ and $x \approx 2$)**:
   - Since $\ln(\Gamma(1)) = 0$ and $\ln(\Gamma(2)) = 0$, evaluating $\ln(\Gamma(x))$ near $x = 1$ or $x = 2$ suffers from catastrophic cancellation in standard polynomial approximations.
   - Boost.Math includes dedicated Taylor/Padé expansions around $x = 1$ and $x = 2$ (using `log1p` variants) to preserve 15–16 significant digits across the zero-crossings.

### Does it matter for `stochtree`?

- Both implementations are accurate to **15–16 decimal digits** ($\approx 10^{-16}$).
- In `stochtree`, `lgamma(a)` is called on shape parameters ($a \ge 2.0$) to compute log-marginal likelihoods. A difference of $< 1$ ULP ($10^{-16}$) is negligible compared to standard floating-point addition order.
