### PR TITLE
Handle kCloglogOrdinal model more thoroughly

### DIFF
--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -492,6 +492,7 @@ void initialize_forest_model_cpp(cpp11::external_pointer<StochTree::ForestDatase
     else if (leaf_model_int == 1) model_type = StochTree::ModelType::kUnivariateRegressionLeafGaussian;
     else if (leaf_model_int == 2) model_type = StochTree::ModelType::kMultivariateRegressionLeafGaussian;
     else if (leaf_model_int == 3) model_type = StochTree::ModelType::kLogLinearVariance;
+    else if (leaf_model_int == 4) model_type = StochTree::ModelType::kCloglogOrdinal;
     else StochTree::Log::Fatal("Invalid model type");
     
     // Unpack initial value
@@ -500,7 +501,8 @@ void initialize_forest_model_cpp(cpp11::external_pointer<StochTree::ForestDatase
     std::vector<double> init_value_vector;
     if ((model_type == StochTree::ModelType::kConstantLeafGaussian) || 
         (model_type == StochTree::ModelType::kUnivariateRegressionLeafGaussian) || 
-        (model_type == StochTree::ModelType::kLogLinearVariance)) {
+        (model_type == StochTree::ModelType::kLogLinearVariance) ||
+        (model_type == StochTree::ModelType::kCloglogOrdinal)) {
         init_val = init_values.at(0);
     } else if (model_type == StochTree::ModelType::kMultivariateRegressionLeafGaussian) {
         int leaf_dim = init_values.size();
@@ -529,6 +531,10 @@ void initialize_forest_model_cpp(cpp11::external_pointer<StochTree::ForestDatase
         int n = data->NumObservations();
         std::vector<double> initial_preds(n, init_val);
         data->AddVarianceWeights(initial_preds.data(), n);
+    } else if (model_type == StochTree::ModelType::kCloglogOrdinal) {
+        forest_samples->InitializeRoot(init_val / static_cast<double>(num_trees));
+        UpdateResidualEntireForest(*tracker, *data, *residual, forest_samples->GetEnsemble(0), false, std::minus<double>());
+        tracker->UpdatePredictions(forest_samples->GetEnsemble(0), *data);
     }
 }
 
@@ -816,7 +822,8 @@ void initialize_forest_model_active_forest_cpp(cpp11::external_pointer<StochTree
     std::vector<double> init_value_vector;
     if ((model_type == StochTree::ModelType::kConstantLeafGaussian) || 
         (model_type == StochTree::ModelType::kUnivariateRegressionLeafGaussian) || 
-        (model_type == StochTree::ModelType::kLogLinearVariance)) {
+        (model_type == StochTree::ModelType::kLogLinearVariance) ||
+        (model_type == StochTree::ModelType::kCloglogOrdinal)) {
         init_val = init_values.at(0);
     } else if (model_type == StochTree::ModelType::kMultivariateRegressionLeafGaussian) {
         int leaf_dim = init_values.size();


### PR DESCRIPTION
This is related to some observed crashes where `init_val` winds up uninitialized, e.g.

https://github.com/StochasticTree/stochtree/blob/main/test/R/testthat/test-predict.R#L686

Written by Gemini. I can share some more thorough diagnostics if needed.