### PR TITLE
Initialize values more consistently

### DIFF
--- a/src/forest.cpp
+++ b/src/forest.cpp
@@ -496,7 +496,7 @@ void initialize_forest_model_cpp(cpp11::external_pointer<StochTree::ForestDatase
     
     // Unpack initial value
     int num_trees = forest_samples->NumTrees();
-    double init_val;
+    double init_val = 0.0;
     std::vector<double> init_value_vector;
     if ((model_type == StochTree::ModelType::kConstantLeafGaussian) || 
         (model_type == StochTree::ModelType::kUnivariateRegressionLeafGaussian) || 
@@ -812,7 +812,7 @@ void initialize_forest_model_active_forest_cpp(cpp11::external_pointer<StochTree
     
     // Unpack initial value
     int num_trees = active_forest->NumTrees();
-    double init_val;
+    double init_val = 0.0;
     std::vector<double> init_value_vector;
     if ((model_type == StochTree::ModelType::kConstantLeafGaussian) || 
         (model_type == StochTree::ModelType::kUnivariateRegressionLeafGaussian) || 

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -56,7 +56,7 @@ void sample_gfr_one_iteration_cpp(cpp11::external_pointer<StochTree::ForestDatas
     else StochTree::Log::Fatal("Invalid model type");
 
     // Unpack leaf model parameters
-    double leaf_scale;
+    double leaf_scale = 0.0;
     Eigen::MatrixXd leaf_scale_matrix;
     if ((model_type == StochTree::ModelType::kConstantLeafGaussian) ||
         (model_type == StochTree::ModelType::kUnivariateRegressionLeafGaussian)) {
@@ -141,7 +141,7 @@ void sample_mcmc_one_iteration_cpp(cpp11::external_pointer<StochTree::ForestData
     else StochTree::Log::Fatal("Invalid model type");
 
     // Unpack leaf model parameters
-    double leaf_scale;
+    double leaf_scale = 0.0;
     Eigen::MatrixXd leaf_scale_matrix;
     if ((model_type == StochTree::ModelType::kConstantLeafGaussian) ||
         (model_type == StochTree::ModelType::kUnivariateRegressionLeafGaussian)) {


### PR DESCRIPTION
#420 fixes some cases where uninitialized values cause a crash; this change gives an additional robustness guarantee by always initializing the variables.