### PR TITLE
Use shallow=true and canonical .git URLs in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,20 +1,25 @@
 [submodule "deps/fast_double_parser"]
 	path = deps/fast_double_parser
-	url = https://github.com/lemire/fast_double_parser/
+	url = https://github.com/lemire/fast_double_parser.git
 	branch = master
+    shallow = true
 [submodule "deps/fmt"]
 	path = deps/fmt
-	url = https://github.com/fmtlib/fmt/
+	url = https://github.com/fmtlib/fmt.git
 	branch = master
+    shallow = true
 [submodule "deps/boost_math"]
 	path = deps/boost_math
-	url = https://github.com/boostorg/math
+	url = https://github.com/boostorg/math.git
 	branch = master
+    shallow = true
 [submodule "deps/eigen"]
 	path = deps/eigen
-	url = https://gitlab.com/libeigen/eigen
+	url = https://gitlab.com/libeigen/eigen.git
 	branch = 3.4
+    shallow = true
 [submodule "deps/pybind11"]
 	path = deps/pybind11
-	url = https://github.com/pybind/pybind11
+	url = https://github.com/pybind/pybind11.git
 	branch = v2.12
+    shallow = true


### PR DESCRIPTION
It's about 2x more common on GitHub ([.git](https://github.com/search?q=path%3A.gitmodules+%2Furl%5Cs*%3D%5B%5E%5Cn%5D*%5C.git%5Cn%2F&type=code) vs [not](https://github.com/search?q=path%3A.gitmodules+%2Furl%5Cs*%3D%5B%5E%5Cn%5D*%28%5C%2F%7C%5B%5Et%5D%7C%5B%5Ei%5Dt%7C%5B%5Eg%5Dit%5D%7C%5B%5E.%5Dgit%29%5Cn%2F&type=code)),  to use the .git approach, and Gemini describes some advantages (HTTP redirects, full robustness, ...)

https://man7.org/linux/man-pages/man5/gitmodules.5.html

`shallow=true` should also be preferable to avoid requiring a full checkout of the repos' histories unless there's a strong need for it.