### PR TITLE
Use Eigen::placeholders::all over Eigen::all

### DIFF
--- a/include/stochtree/random_effects.h
+++ b/include/stochtree/random_effects.h
@@ -155,7 +155,7 @@ class MultivariateRegressionRandomEffectsModel {
     group_parameters_ = group_parameters;
   }
   void SetGroupParameter(Eigen::VectorXd& group_parameter, int32_t group_id) {
-    group_parameters_(Eigen::all, group_id) = group_parameter;
+    group_parameters_(Eigen::placeholders::all, group_id) = group_parameter;
   }
   void SetWorkingParameterCovariance(Eigen::MatrixXd& working_parameter_covariance) {
     working_parameter_covariance_ = working_parameter_covariance;
@@ -211,7 +211,7 @@ class MultivariateRegressionRandomEffectsModel {
     std::int32_t group_ind;
     for (int i = 0; i < n; i++) {
       group_ind = tracker.CategoryNumber(group_labels[i]);
-      output[i] = X(i, Eigen::all) * alpha_diag * group_parameters_(Eigen::all, group_ind);
+      output[i] = X(i, Eigen::placeholders::all) * alpha_diag * group_parameters_(Eigen::placeholders::all, group_ind);
     }
   }
 
@@ -238,7 +238,7 @@ class MultivariateRegressionRandomEffectsModel {
     std::int32_t group_ind;
     for (int i = 0; i < n; i++) {
       group_ind = tracker.CategoryNumber(group_labels[i]);
-      new_pred = X(i, Eigen::all) * alpha_diag * group_parameters_(Eigen::all, group_ind);
+      new_pred = X(i, Eigen::placeholders::all) * alpha_diag * group_parameters_(Eigen::placeholders::all, group_ind);
       new_resid = residual.GetElement(i) - new_pred;
       residual.SetElement(i, new_resid);
       tracker.SetPrediction(i, new_pred);

--- a/src/random_effects.cpp
+++ b/src/random_effects.cpp
@@ -54,7 +54,7 @@ void RandomEffectsTracker::ResetFromSample(MultivariateRegressionRandomEffectsMo
   for (int i = 0; i < n; i++) {
     group_ind = CategoryNumber(group_labels[i]);
     prev_pred = GetPrediction(i);
-    new_pred = X(i, Eigen::all) * alpha_diag * xi(Eigen::all, group_ind);
+    new_pred = X(i, Eigen::placeholders::all) * alpha_diag * xi(Eigen::placeholders::all, group_ind);
     new_resid = residual.GetElement(i) - new_pred + prev_pred;
     residual.SetElement(i, new_resid);
     SetPrediction(i, new_pred);
@@ -123,7 +123,7 @@ void MultivariateRegressionRandomEffectsModel::SampleGroupParameters(RandomEffec
   for (int i = 0; i < num_groups; i++) {
     posterior_mean = GroupParameterMean(dataset, residual, rfx_tracker, global_variance, i);
     posterior_covariance = GroupParameterVariance(dataset, residual, rfx_tracker, global_variance, i);
-    group_parameters_(Eigen::all, i) = normal_sampler_.SampleEigen(posterior_mean, posterior_covariance, gen);
+    group_parameters_(Eigen::placeholders::all, i) = normal_sampler_.SampleEigen(posterior_mean, posterior_covariance, gen);
   }  
 }
 
@@ -155,9 +155,9 @@ Eigen::VectorXd MultivariateRegressionRandomEffectsModel::WorkingParameterMean(R
   Eigen::MatrixXd xi = group_parameters_;
   for (int i = 0; i < num_groups; i++) {
     observation_indices = rfx_tracker.NodeIndicesInternalIndex(i);
-    X_group = X(observation_indices, Eigen::all);
-    y_group = y(observation_indices, Eigen::all);
-    xi_group = xi(Eigen::all, i);
+    X_group = X(observation_indices, Eigen::placeholders::all);
+    y_group = y(observation_indices, Eigen::placeholders::all);
+    xi_group = xi(Eigen::placeholders::all, i);
     posterior_denominator += ((xi_group).asDiagonal() * X_group.transpose() * X_group * (xi_group).asDiagonal()) / global_variance;
     posterior_numerator += (xi_group).asDiagonal() * X_group.transpose() * y_group / global_variance;
   }
@@ -178,9 +178,9 @@ Eigen::MatrixXd MultivariateRegressionRandomEffectsModel::WorkingParameterVarian
   Eigen::MatrixXd xi = group_parameters_;
   for (int i = 0; i < num_groups; i++) {
     observation_indices = rfx_tracker.NodeIndicesInternalIndex(i);
-    X_group = X(observation_indices, Eigen::all);
-    y_group = y(observation_indices, Eigen::all);
-    xi_group = xi(Eigen::all, i);
+    X_group = X(observation_indices, Eigen::placeholders::all);
+    y_group = y(observation_indices, Eigen::placeholders::all);
+    xi_group = xi(Eigen::placeholders::all, i);
     posterior_denominator += ((xi_group).asDiagonal() * X_group.transpose() * X_group * (xi_group).asDiagonal()) / (global_variance);
   }
   return posterior_denominator.inverse();
@@ -195,8 +195,8 @@ Eigen::VectorXd MultivariateRegressionRandomEffectsModel::GroupParameterMean(Ran
   Eigen::MatrixXd posterior_denominator = group_parameter_covariance_.inverse();
   Eigen::VectorXd posterior_numerator = Eigen::VectorXd::Zero(num_components);
   std::vector<data_size_t> observation_indices = rfx_tracker.NodeIndicesInternalIndex(group_id);
-  Eigen::MatrixXd X_group = X(observation_indices, Eigen::all);
-  Eigen::VectorXd y_group = y(observation_indices, Eigen::all);
+  Eigen::MatrixXd X_group = X(observation_indices, Eigen::placeholders::all);
+  Eigen::VectorXd y_group = y(observation_indices, Eigen::placeholders::all);
   posterior_denominator += ((alpha).asDiagonal() * X_group.transpose() * X_group * (alpha).asDiagonal()) / (global_variance);
   posterior_numerator += (alpha).asDiagonal() * X_group.transpose() * y_group / global_variance;
   return posterior_denominator.inverse() * posterior_numerator;
@@ -211,8 +211,8 @@ Eigen::MatrixXd MultivariateRegressionRandomEffectsModel::GroupParameterVariance
   Eigen::MatrixXd posterior_denominator = group_parameter_covariance_.inverse();
 //  Eigen::VectorXd posterior_numerator = Eigen::VectorXd::Zero(num_components);
   std::vector<data_size_t> observation_indices = rfx_tracker.NodeIndicesInternalIndex(group_id);
-  Eigen::MatrixXd X_group = X(observation_indices, Eigen::all);
-//  Eigen::VectorXd y_group = y(observation_indices, Eigen::all);
+  Eigen::MatrixXd X_group = X(observation_indices, Eigen::placeholders::all);
+//  Eigen::VectorXd y_group = y(observation_indices, Eigen::placeholders::all);
   posterior_denominator += ((alpha).asDiagonal() * X_group.transpose() * X_group * (alpha).asDiagonal()) / (global_variance);
 //  posterior_numerator += (alpha).asDiagonal() * X_group.transpose() * y_group;
   return posterior_denominator.inverse();

--- a/test/cpp/test_random_effects.cpp
+++ b/test/cpp/test_random_effects.cpp
@@ -58,8 +58,8 @@ TEST(RandomEffects, Construction) {
   Eigen::MatrixXd sigma(test_dataset.rfx_basis_cols, test_dataset.rfx_basis_cols);
   alpha << 1.5;
   xi << 2, 4;
-  Eigen::VectorXd xi0 = xi(Eigen::all, 0);
-  Eigen::VectorXd xi1 = xi(Eigen::all, 1);
+  Eigen::VectorXd xi0 = xi(Eigen::placeholders::all, 0);
+  Eigen::VectorXd xi1 = xi(Eigen::placeholders::all, 1);
   sigma << 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);
@@ -72,8 +72,8 @@ TEST(RandomEffects, Construction) {
   // Change values and push a second "sample" to the container
   alpha << 2.0;
   xi << 1, 3;
-  xi0 = xi(Eigen::all, 0);
-  xi1 = xi(Eigen::all, 1);
+  xi0 = xi(Eigen::placeholders::all, 0);
+  xi1 = xi(Eigen::placeholders::all, 1);
   sigma << 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);
@@ -124,9 +124,9 @@ TEST(RandomEffects, Computation) {
   Eigen::MatrixXd sigma(test_dataset.rfx_basis_cols, test_dataset.rfx_basis_cols);
   alpha << 1., 1.;
   xi << 1., 1., 1., 1., 1., 1.;
-  Eigen::VectorXd xi0 = xi(Eigen::all, 0);
-  Eigen::VectorXd xi1 = xi(Eigen::all, 1);
-  Eigen::VectorXd xi2 = xi(Eigen::all, 2);
+  Eigen::VectorXd xi0 = xi(Eigen::placeholders::all, 0);
+  Eigen::VectorXd xi1 = xi(Eigen::placeholders::all, 1);
+  Eigen::VectorXd xi2 = xi(Eigen::placeholders::all, 2);
   sigma << 1, 0, 0, 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);
@@ -180,8 +180,8 @@ TEST(RandomEffects, Predict) {
   Eigen::MatrixXd sigma(test_dataset.rfx_basis_cols, test_dataset.rfx_basis_cols);
   alpha << 1.5;
   xi << 2, 4;
-  Eigen::VectorXd xi0 = xi(Eigen::all, 0);
-  Eigen::VectorXd xi1 = xi(Eigen::all, 1);
+  Eigen::VectorXd xi0 = xi(Eigen::placeholders::all, 0);
+  Eigen::VectorXd xi1 = xi(Eigen::placeholders::all, 1);
   sigma << 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);
@@ -194,8 +194,8 @@ TEST(RandomEffects, Predict) {
   // Change values and push a second "sample" to the container
   alpha << 2.0;
   xi << 1, 3;
-  xi0 = xi(Eigen::all, 0);
-  xi1 = xi(Eigen::all, 1);
+  xi0 = xi(Eigen::placeholders::all, 0);
+  xi1 = xi(Eigen::placeholders::all, 1);
   sigma << 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);
@@ -242,8 +242,8 @@ TEST(RandomEffects, Serialization) {
   Eigen::MatrixXd sigma(test_dataset.rfx_basis_cols, test_dataset.rfx_basis_cols);
   alpha << 1.5;
   xi << 2, 4;
-  Eigen::VectorXd xi0 = xi(Eigen::all, 0);
-  Eigen::VectorXd xi1 = xi(Eigen::all, 1);
+  Eigen::VectorXd xi0 = xi(Eigen::placeholders::all, 0);
+  Eigen::VectorXd xi1 = xi(Eigen::placeholders::all, 1);
   sigma << 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);
@@ -256,8 +256,8 @@ TEST(RandomEffects, Serialization) {
   // Change values and push a second "sample" to the container
   alpha << 2.0;
   xi << 1, 3;
-  xi0 = xi(Eigen::all, 0);
-  xi1 = xi(Eigen::all, 1);
+  xi0 = xi(Eigen::placeholders::all, 0);
+  xi1 = xi(Eigen::placeholders::all, 1);
   sigma << 1;
   model.SetWorkingParameter(alpha);
   model.SetGroupParameter(xi0, 0);


### PR DESCRIPTION
Possibly a fix for #423 -- at least it avoids `Eigen::all` and enables {stochtree} to be compiled against a wider range of `eigen` versions.