### PR TITLE
Fix extrema calculation in MCMC split-range and node-constant helpers

### DIFF
--- a/include/stochtree/tree_sampler.h
+++ b/include/stochtree/tree_sampler.h
@@ -47,7 +47,7 @@ namespace StochTree {
  */
 static inline void VarSplitRange(ForestTracker& tracker, ForestDataset& dataset, int tree_num, int leaf_split, int feature_split, double& var_min, double& var_max) {
   var_min = std::numeric_limits<double>::max();
-  var_max = std::numeric_limits<double>::min();
+  var_max = std::numeric_limits<double>::lowest();
   double feature_value;
   
   std::vector<data_size_t>::iterator node_begin_iter = tracker.UnsortedNodeBeginIterator(tree_num, leaf_split);
@@ -58,7 +58,8 @@ static inline void VarSplitRange(ForestTracker& tracker, ForestDataset& dataset,
     feature_value = dataset.CovariateValue(idx, feature_split);
     if (feature_value < var_min) {
       var_min = feature_value;
-    } else if (feature_value > var_max) {
+    }
+    if (feature_value > var_max) {
       var_max = feature_value;
     }
   }
@@ -88,9 +89,9 @@ static inline bool NodesNonConstantAfterSplit(ForestDataset& dataset, ForestTrac
   for (int j = 0; j < p; j++) {
     auto node_begin_iter = tracker.UnsortedNodeBeginIterator(tree_num, leaf_split);
     auto node_end_iter = tracker.UnsortedNodeEndIterator(tree_num, leaf_split);
-    var_max_left = std::numeric_limits<double>::min();
+    var_max_left = std::numeric_limits<double>::lowest();
     var_min_left = std::numeric_limits<double>::max();
-    var_max_right = std::numeric_limits<double>::min();
+    var_max_right = std::numeric_limits<double>::lowest();
     var_min_right = std::numeric_limits<double>::max();
 
     for (auto i = node_begin_iter; i != node_end_iter; i++) {
@@ -100,13 +101,15 @@ static inline bool NodesNonConstantAfterSplit(ForestDataset& dataset, ForestTrac
       if (split.SplitTrue(split_feature_value)) {
         if (var_max_left < feature_value) {
           var_max_left = feature_value;
-        } else if (var_min_left > feature_value) {
+        }
+        if (var_min_left > feature_value) {
           var_min_left = feature_value;
         }
       } else {
         if (var_max_right < feature_value) {
           var_max_right = feature_value;
-        } else if (var_min_right > feature_value) {
+        }
+        if (var_min_right > feature_value) {
           var_min_right = feature_value;
         }
       }
@@ -128,7 +131,7 @@ static inline bool NodeNonConstant(ForestDataset& dataset, ForestTracker& tracke
   for (int j = 0; j < p; j++) {
     auto node_begin_iter = tracker.UnsortedNodeBeginIterator(tree_num, node_id);
     auto node_end_iter = tracker.UnsortedNodeEndIterator(tree_num, node_id);
-    var_max = std::numeric_limits<double>::min();
+    var_max = std::numeric_limits<double>::lowest();
     var_min = std::numeric_limits<double>::max();
 
     for (auto i = node_begin_iter; i != node_end_iter; i++) {
@@ -136,7 +139,8 @@ static inline bool NodeNonConstant(ForestDataset& dataset, ForestTracker& tracke
       feature_value = dataset.CovariateValue(idx, j);
       if (var_max < feature_value) {
         var_max = feature_value;
-      } else if (var_min > feature_value) {
+      }
+      if (var_min > feature_value) {
         var_min = feature_value;
       }
     }

--- a/test/cpp/test_sampler_extrema.cpp
+++ b/test/cpp/test_sampler_extrema.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+#include <stochtree/tree_sampler.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace {
+
+// One numeric feature and one root node; no sampling or random seed is needed.
+struct RootData {
+  StochTree::ForestDataset dataset;
+  std::vector<StochTree::FeatureType> types{StochTree::FeatureType::kNumeric};
+
+  explicit RootData(std::vector<double> values) {
+    dataset.AddCovariates(values.data(), values.size(), 1, true);
+  }
+};
+
+}  // namespace
+
+TEST(SamplerExtrema, RangeIsIndependentOfOrderAndSign) {
+  for (auto values : std::vector<std::vector<double>>{
+           {1, 2, 3}, {-3, -2, -1}, {-1, 0, 1}, {0, 0}, {-2, -2}, {7}}) {
+    const double expected_min = values.front();
+    const double expected_max = values.back();
+    do {
+      SCOPED_TRACE(::testing::PrintToString(values));
+      RootData data(values);
+      StochTree::ForestTracker tracker(data.dataset.GetCovariates(), data.types, 1, values.size());
+      double lower, upper;
+      StochTree::VarSplitRange(tracker, data.dataset, 0, 0, 0, lower, upper);
+      EXPECT_DOUBLE_EQ(lower, expected_min);
+      EXPECT_DOUBLE_EQ(upper, expected_max);
+    } while (std::next_permutation(values.begin(), values.end()));
+  }
+}
+
+TEST(SamplerExtrema, RecognizesConstantAndVaryingNodes) {
+  for (auto values : std::vector<std::vector<double>>{
+           {1, 2, 3}, {-3, -2, -1}, {0, 0}, {-2, -2}, {2, 2}, {7}}) {
+    const bool expected = values.front() != values.back();
+    do {
+      SCOPED_TRACE(::testing::PrintToString(values));
+      RootData data(values);
+      StochTree::ForestTracker tracker(data.dataset.GetCovariates(), data.types, 1, values.size());
+      EXPECT_EQ(StochTree::NodeNonConstant(data.dataset, tracker, 0, 0), expected);
+    } while (std::next_permutation(values.begin(), values.end()));
+  }
+}
+
+TEST(SamplerExtrema, RecognizesConstantAndVaryingChildren) {
+  for (auto values : std::vector<std::vector<double>>{
+           {1, 2, 3, 4}, {-4, -3, -2, -1}, {-2, -2, -1, -1}}) {
+    const double threshold = (values[1] + values[2]) / 2;
+    const bool expected = values[0] != values[1] && values[2] != values[3];
+    do {
+      SCOPED_TRACE(::testing::PrintToString(values));
+      RootData data(values);
+      StochTree::ForestTracker tracker(data.dataset.GetCovariates(), data.types, 1, values.size());
+      StochTree::TreeSplit split(threshold);
+      EXPECT_EQ(StochTree::NodesNonConstantAfterSplit(data.dataset, tracker, split, 0, 0, 0), expected);
+    } while (std::next_permutation(values.begin(), values.end()));
+  }
+}


### PR DESCRIPTION
Hello,

I bumped into this issue in the course of a modelling project involving many thousands of model fits. I had GPT 6 Astra get to the bottom of the problem; it found the issue and proposed the solution, and I've verified that it works, at least on my local machine.

Here's the issue, solution and reprex:

`VarSplitRange()` can return an inverted interval for a varying numeric feature: observations visited in order `3, 2, 1` produce `[1, DBL_MIN]` instead of `[1, 3]`. `MCMCGrowTreeOneIter()` then returns without proposing a split because the upper bound is below the lower bound. Negative features can instead get an upper bound near zero even when all observations are strictly negative.

There are two causes: `numeric_limits<double>::min()` is the smallest positive normalized double, and the `if/else if` extrema update prevents an observation from updating both bounds. The latter also makes results depend on iteration order. `NodeNonConstant()` and `NodesNonConstantAfterSplit()` use the same patterns and can misclassify varying positive or constant nonpositive features.

This patch initializes maxima with `lowest()` and updates both extrema independently in all three helpers. It preserves their signatures and existing control flow, including the child-constant combination logic. Three deterministic GoogleTest cases exercise ranges and constant checks over permutations of small positive, negative, mixed-sign, constant and singleton inputs. They call the real helpers with `ForestDataset` and `ForestTracker`; no stochastic model fit is needed.

Minimal reproduction (also covered by `SamplerExtrema.RangeIsIndependentOfOrderAndSign`):

```cpp
std::vector<double> x{3, 2, 1};
StochTree::ForestDataset data;
data.AddCovariates(x.data(), 3, 1, true);
std::vector<StochTree::FeatureType> types{StochTree::FeatureType::kNumeric};
StochTree::ForestTracker tracker(data.GetCovariates(), types, 1, 3);
double lo, hi;
StochTree::VarSplitRange(tracker, data, 0, 0, 0, lo, hi);
// Before: lo == 1, hi == std::numeric_limits<double>::min()
// After:  lo == 1, hi == 3
```

Validation on macOS ARM64 with Apple Clang, C++17 and OpenMP disabled:

- Before the fix, all three new regression tests fail.
- After the fix, all 31 C++ tests pass, including the three new tests.
- The standalone reproducer changes from `[1, 2.2250738585072014e-308]`
  (exit 1) to `[1, 3]` (exit 0).