### PR TITLE
Use consistent forward/reverse probabilities in MCMC grow/prune moves

### DIFF
--- a/include/stochtree/tree_sampler.h
+++ b/include/stochtree/tree_sampler.h
@@ -859,6 +859,70 @@ static inline void GFRSampleOneIter(TreeEnsemble& active_forest, ForestTracker& 
   }
 }
 
+// Proposal availability uses observation counts only. Selecting a constant
+// variable or a leaf at maximum depth still yields a rejected grow proposal.
+struct MCMCProposalState {
+  int leaves;
+  int leaf_parents;
+  int grow_candidates;
+  double GrowProbability() const {
+    return grow_candidates > 0 ? (leaf_parents > 0 ? 0.5 : 1.0) : 0.0;
+  }
+  double PruneProbability() const {
+    return leaf_parents > 0 ? (grow_candidates > 0 ? 0.5 : 1.0) : 0.0;
+  }
+};
+
+static inline bool MCMCSizeAllowsGrow(data_size_t n, int minimum) {
+  // Equality permits two children with exactly minimum observations each.
+  return n >= 2 * minimum;
+}
+
+static inline MCMCProposalState MCMCGetProposalState(Tree* tree, ForestTracker& tracker, int tree_num, int minimum) {
+  MCMCProposalState state{tree->NumLeaves(), tree->NumLeafParents(), 0};
+  for (int leaf : tree->GetLeaves()) {
+    state.grow_candidates += MCMCSizeAllowsGrow(tracker.UnsortedNodeSize(tree_num, leaf), minimum);
+  }
+  return state;
+}
+
+static inline MCMCProposalState MCMCStateAfterGrow(Tree* tree, MCMCProposalState state, int leaf,
+                                                  data_size_t left_n, data_size_t right_n, int minimum) {
+  state.leaves += 1;
+  state.leaf_parents += 1;
+  if (!tree->IsRoot(leaf) && tree->IsLeafParent(tree->Parent(leaf))) {
+    state.leaf_parents -= 1;
+  }
+  state.grow_candidates += MCMCSizeAllowsGrow(left_n, minimum) + MCMCSizeAllowsGrow(right_n, minimum)
+                          - MCMCSizeAllowsGrow(left_n + right_n, minimum);
+  return state;
+}
+
+static inline MCMCProposalState MCMCStateAfterPrune(Tree* tree, MCMCProposalState state, int node,
+                                                   data_size_t left_n, data_size_t right_n, int minimum) {
+  state.leaves -= 1;
+  state.leaf_parents -= 1;
+  if (!tree->IsRoot(node)) {
+    int parent = tree->Parent(node);
+    int sibling = tree->LeftChild(parent) == node ? tree->RightChild(parent) : tree->LeftChild(parent);
+    if (tree->IsLeaf(sibling)) state.leaf_parents += 1;
+  }
+  state.grow_candidates += MCMCSizeAllowsGrow(left_n + right_n, minimum)
+                          - MCMCSizeAllowsGrow(left_n, minimum) - MCMCSizeAllowsGrow(right_n, minimum);
+  return state;
+}
+
+// The split-rule density cancels with the corresponding conditional tree prior.
+// These terms cover move type and uniform leaf / leaf-parent selection only.
+static inline double MCMCLogProposalRatio(const MCMCProposalState& from, const MCMCProposalState& to, bool grow) {
+  if (grow) {
+    return std::log(to.PruneProbability()) - std::log(static_cast<double>(to.leaf_parents))
+           - std::log(from.GrowProbability()) + std::log(static_cast<double>(from.leaves));
+  }
+  return std::log(to.GrowProbability()) - std::log(static_cast<double>(to.leaves))
+         - std::log(from.PruneProbability()) + std::log(static_cast<double>(from.leaf_parents));
+}
+
 template <typename LeafModel, typename LeafSuffStat, typename... LeafSuffStatConstructorArgs>
 static inline void MCMCGrowTreeOneIter(Tree* tree, ForestTracker& tracker, LeafModel& leaf_model, ForestDataset& dataset, ColumnVector& residual, 
                                        TreePrior& tree_prior, std::mt19937& gen, int tree_num, std::vector<double>& variable_weights, 
@@ -923,28 +987,13 @@ static inline void MCMCGrowTreeOneIter(Tree* tree, ForestTracker& tracker, LeafM
       double pgl = tree_prior.GetAlpha() * std::pow(1+leaf_depth+1, -tree_prior.GetBeta());
       double pgr = tree_prior.GetAlpha() * std::pow(1+leaf_depth+1, -tree_prior.GetBeta());
 
-      // Determine whether a "grow" move is possible from the newly formed tree
-      // in order to compute the probability of choosing "prune" from the new tree
-      // (which is always possible by construction)
-      bool non_constant = NodesNonConstantAfterSplit(dataset, tracker, split, tree_num, leaf_chosen, var_chosen);
-      bool min_samples_left_check = left_n >= 2*tree_prior.GetMinSamplesLeaf();
-      bool min_samples_right_check = right_n >= 2*tree_prior.GetMinSamplesLeaf();
-      double prob_prune_new;
-      if (non_constant && (min_samples_left_check || min_samples_right_check)) {
-        prob_prune_new = 0.5;
-      } else {
-        prob_prune_new = 1.0;
-      }
-
-      // Determine the number of leaves in the current tree and leaf parents in the proposed tree
-      int num_leaf_parents = tree->NumLeafParents();
-      double p_leaf = 1/static_cast<double>(num_leaves);
-      double p_leaf_parent = 1/static_cast<double>(num_leaf_parents+1);
+      auto old_state = MCMCGetProposalState(tree, tracker, tree_num, tree_prior.GetMinSamplesLeaf());
+      auto new_state = MCMCStateAfterGrow(tree, old_state, leaf_chosen, left_n, right_n, tree_prior.GetMinSamplesLeaf());
 
       // Compute the final MH ratio
       double log_mh_ratio = (
-        std::log(pg) + std::log(1-pgl) + std::log(1-pgr) - std::log(1-pg) + std::log(prob_prune_new) +
-        std::log(p_leaf_parent) - std::log(prob_grow_old) - std::log(p_leaf) - no_split_log_marginal_likelihood + split_log_marginal_likelihood
+        std::log(pg) + std::log(1-pgl) + std::log(1-pgr) - std::log(1-pg) +
+        MCMCLogProposalRatio(old_state, new_state, true) - no_split_log_marginal_likelihood + split_log_marginal_likelihood
       );
       // Threshold at 0
       if (log_mh_ratio > 0) {
@@ -997,36 +1046,13 @@ static inline void MCMCPruneTreeOneIter(Tree* tree, ForestTracker& tracker, Leaf
   double pgl = tree_prior.GetAlpha() * std::pow(1+leaf_parent_depth+1, -tree_prior.GetBeta());
   double pgr = tree_prior.GetAlpha() * std::pow(1+leaf_parent_depth+1, -tree_prior.GetBeta());
 
-  // Determine whether a "prune" move is possible from the new tree,
-  // in order to compute the probability of choosing "grow" from the new tree
-  // (which is always possible by construction)
-  bool non_root_tree = tree->NumNodes() > 1;
-  double prob_grow_new;
-  if (non_root_tree) {
-    prob_grow_new = 0.5;
-  } else {
-    prob_grow_new = 1.0;
-  }
-
-  // Determine whether a "grow" move was possible from the old tree,
-  // in order to compute the probability of choosing "prune" from the old tree
-  bool non_constant_left = NodeNonConstant(dataset, tracker, tree_num, left_node);
-  bool non_constant_right = NodeNonConstant(dataset, tracker, tree_num, right_node);
-  double prob_prune_old;
-  if (non_constant_left && non_constant_right) {
-    prob_prune_old = 0.5;
-  } else {
-    prob_prune_old = 1.0;
-  }
-
-  // Determine the number of leaves in the current tree and leaf parents in the proposed tree
-  double p_leaf = 1/static_cast<double>(num_leaves-1);
-  double p_leaf_parent = 1/static_cast<double>(num_leaf_parents);
+  auto old_state = MCMCGetProposalState(tree, tracker, tree_num, tree_prior.GetMinSamplesLeaf());
+  auto new_state = MCMCStateAfterPrune(tree, old_state, leaf_parent_chosen, left_n, right_n, tree_prior.GetMinSamplesLeaf());
 
   // Compute the final MH ratio
   double log_mh_ratio = (
-    std::log(1-pg) - std::log(pg) - std::log(1-pgl) - std::log(1-pgr) + std::log(prob_prune_old) +
-    std::log(p_leaf) - std::log(prob_grow_new) - std::log(p_leaf_parent) + no_split_log_marginal_likelihood - split_log_marginal_likelihood
+    std::log(1-pg) - std::log(pg) - std::log(1-pgl) - std::log(1-pgr) +
+    MCMCLogProposalRatio(old_state, new_state, false) + no_split_log_marginal_likelihood - split_log_marginal_likelihood
   );
   // Threshold at 0
   if (log_mh_ratio > 0) {
@@ -1048,37 +1074,12 @@ template <typename LeafModel, typename LeafSuffStat, typename... LeafSuffStatCon
 static inline void MCMCSampleTreeOneIter(Tree* tree, ForestTracker& tracker, ForestContainer& forests, LeafModel& leaf_model, ForestDataset& dataset,
                                          ColumnVector& residual, TreePrior& tree_prior, std::mt19937& gen, std::vector<double>& variable_weights, 
                                          int tree_num, double global_variance, int num_threads, LeafSuffStatConstructorArgs&... leaf_suff_stat_args) {
-  // Determine whether it is possible to grow any of the leaves
-  bool grow_possible = false;
-  std::vector<int> leaves = tree->GetLeaves();
-  for (auto& leaf: leaves) {
-    if (tracker.UnsortedNodeSize(tree_num, leaf) > 2 * tree_prior.GetMinSamplesLeaf()) {
-      grow_possible = true;
-      break;
-    }
-  }
-
-  // Determine whether it is possible to prune the tree
-  bool prune_possible = false;
-  if (tree->NumValidNodes() > 1) {
-    prune_possible = true;
-  }
-
-  // Determine the relative probability of grow vs prune (0 = grow, 1 = prune)
-  double prob_grow;
-  std::vector<double> step_probs(2);
-  if (grow_possible && prune_possible) {
-    step_probs = {0.5, 0.5};
-    prob_grow = 0.5;
-  } else if (!grow_possible && prune_possible) {
-    step_probs = {0.0, 1.0};
-    prob_grow = 0.0;
-  } else if (grow_possible && !prune_possible) {
-    step_probs = {1.0, 0.0};
-    prob_grow = 1.0;
-  } else {
-    Log::Fatal("In this tree, neither grow nor prune is possible");
-  }
+  auto state = MCMCGetProposalState(tree, tracker, tree_num, tree_prior.GetMinSamplesLeaf());
+  double prob_grow = state.GrowProbability();
+  double prob_prune = state.PruneProbability();
+  // An undersized root has no legal move; retain the current tree.
+  if (prob_grow == 0.0 && prob_prune == 0.0) return;
+  std::vector<double> step_probs{prob_grow, prob_prune};
   walker_vose step_dist(step_probs.begin(), step_probs.end());
 
   // Draw a split rule at random

--- a/test/cpp/test_sampler_acceptance.cpp
+++ b/test/cpp/test_sampler_acceptance.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+#include <stochtree/tree_sampler.h>
+#include <numeric>
+
+namespace {
+struct ProposalFixture {
+  StochTree::ForestDataset data;
+  std::vector<StochTree::FeatureType> types{StochTree::FeatureType::kNumeric};
+  StochTree::Tree tree;
+  std::unique_ptr<StochTree::ForestTracker> tracker;
+  StochTree::TreePrior prior{0.6, 2., 2};
+  std::mt19937 gen{19};
+  ProposalFixture(int n) {
+    std::vector<double> x(n); std::iota(x.begin(), x.end(), 0.);
+    data.AddCovariates(x.data(), n, 1, true);
+    tracker = std::make_unique<StochTree::ForestTracker>(data.GetCovariates(), types, 1, n);
+    tree.Init(1);
+  }
+  auto State() { return StochTree::MCMCGetProposalState(&tree, *tracker, 0, prior.GetMinSamplesLeaf()); }
+  void Grow(int leaf, double cut) {
+    StochTree::TreeSplit split(cut);
+    StochTree::AddSplitToModel(*tracker, data, prior, split, gen, &tree, 0, leaf, 0);
+  }
+};
+void Same(const StochTree::MCMCProposalState& a, const StochTree::MCMCProposalState& b) {
+  EXPECT_EQ(a.leaves, b.leaves); EXPECT_EQ(a.leaf_parents, b.leaf_parents);
+  EXPECT_EQ(a.grow_candidates, b.grow_candidates);
+}
+}
+
+TEST(SamplerAcceptance, GrowThenPruneUsesActualWholeTreeState) {
+  ProposalFixture f(12);
+  for (auto proposal : std::vector<std::pair<int,double>>{{0,3.5},{2,7.5},{1,1.5}}) {
+    int leaf=proposal.first;
+    int n=f.tracker->UnsortedNodeSize(0,leaf);
+    int left_n=0;
+    for (auto i=f.tracker->UnsortedNodeBeginIterator(0,leaf);i!=f.tracker->UnsortedNodeEndIterator(0,leaf);++i)
+      left_n += f.data.CovariateValue(*i,0)<=proposal.second;
+    auto old=f.State();
+    auto predicted=StochTree::MCMCStateAfterGrow(&f.tree,old,leaf,left_n,n-left_n,2);
+    f.Grow(leaf,proposal.second);
+    auto actual=f.State(); Same(predicted,actual);
+    auto reverse=StochTree::MCMCStateAfterPrune(&f.tree,actual,leaf,left_n,n-left_n,2);
+    Same(reverse,old);
+    double q_forward=old.GrowProbability()/old.leaves;
+    double q_reverse=actual.PruneProbability()/actual.leaf_parents;
+    EXPECT_NEAR(StochTree::MCMCLogProposalRatio(old,actual,true),std::log(q_reverse/q_forward),1e-14);
+    EXPECT_NEAR(StochTree::MCMCLogProposalRatio(actual,old,false),std::log(q_forward/q_reverse),1e-14);
+  }
+}
+
+TEST(SamplerAcceptance, OtherLeavesAndLeafParentReplacementMatter) {
+  ProposalFixture f(20); f.Grow(0,3.5);
+  auto old=f.State();
+  auto next=StochTree::MCMCStateAfterGrow(&f.tree,old,1,2,2,2);
+  f.Grow(1,1.5); Same(next,f.State());
+  EXPECT_EQ(next.leaf_parents,1); // root stops being a leaf parent
+  EXPECT_EQ(next.grow_candidates,1); // the unaffected 16-observation leaf
+  EXPECT_DOUBLE_EQ(next.PruneProbability(),0.5);
+}
+
+TEST(SamplerAcceptance, EqualityBoundaryAndPruningToRoot) {
+  ProposalFixture f(4);
+  auto root=f.State(); EXPECT_DOUBLE_EQ(root.GrowProbability(),1.);
+  f.Grow(0,1.5); auto split=f.State();
+  EXPECT_DOUBLE_EQ(split.PruneProbability(),1.);
+  auto back=StochTree::MCMCStateAfterPrune(&f.tree,split,0,2,2,2);
+  Same(back,root); EXPECT_DOUBLE_EQ(back.GrowProbability(),1.);
+  EXPECT_DOUBLE_EQ(StochTree::MCMCLogProposalRatio(root,split,true),0.);
+  EXPECT_DOUBLE_EQ(StochTree::MCMCLogProposalRatio(split,root,false),0.);
+}
+
+TEST(SamplerAcceptance, InactiveNodesDoNotPreventRootProbability) {
+  ProposalFixture f(8); f.Grow(0,3.5);
+  StochTree::RemoveSplitFromModel(*f.tracker,f.data,f.prior,f.gen,&f.tree,0,0,1,2);
+  EXPECT_DOUBLE_EQ(f.State().GrowProbability(),1.);
+  EXPECT_DOUBLE_EQ(f.State().PruneProbability(),0.);
+}
+
+TEST(SamplerAcceptance, UndersizedRootRetainsTree) {
+  ProposalFixture f(3);
+  std::vector<double> y(3,0.); StochTree::ColumnVector residual(y.data(),3);
+  StochTree::GaussianConstantLeafModel model(1.);
+  StochTree::ForestContainer forests(1); std::vector<double> weights{1.};
+  StochTree::MCMCSampleTreeOneIter<StochTree::GaussianConstantLeafModel,StochTree::GaussianConstantSuffStat>(
+    &f.tree,*f.tracker,forests,model,f.data,residual,f.prior,f.gen,weights,0,1.,1);
+  EXPECT_EQ(f.tree.NumLeaves(),1);
+}


### PR DESCRIPTION
Hi,

Here's the second of two issues uncovered with my current modelling run. Again, fix and reprex are both included.

### Overview

The grow/prune acceptance formulas use proposal probabilities that differ from those used to select moves. This can violate detailed balance even with finite numeric covariates. This PR computes move probabilities from shared whole-tree state and uses reverse-over-forward probabilities in both acceptance ratios.

This branch is based directly on upstream main at `5c09ac77e4125d078a9ae0ad5b29e71b33615a5c`. It contains only the acceptance fix and its tests. The numeric-extrema correction is a separate PR; the exact-posterior validation described below includes that correction to isolate acceptance logic.

### Problems

- The prune formula uses `log(prob_prune_old) - log(prob_grow_new)`; the proposal  ratio requires the opposite signs.
- The reverse grow probability after pruning uses the pre-prune `NumNodes()`.  This gives 0.5 when pruning to a root should give 1, and allocated-node counts  can include deleted nodes.
- Growing a leaf always assumes the number of reverse-prune choices increases by one. If its sibling is a leaf, the old parent ceases to be a leaf parent, so the count stays unchanged.
- Acceptance calculations inspect the affected children and feature constancy, whereas move dispatch uses the sizes of all leaves. Unaffected leaves can therefore make the calculated and actual move probabilities disagree.
- Dispatch's strict `n > 2 * min_leaf` cutoff excludes valid equal-size boundary splits. An undersized root currently causes a fatal error despite having a valid no-op transition.

### Reproductions and intended ratio

Let `L(T)` be the number of leaves, `B(T)` the number of prune choices, and `g(T)` / `p(T)` the actual probabilities of choosing grow / prune. For a grow `T -> T+`, the move-type/node-selection ratio is

```
[p(T+) / B(T+)] / [g(T) / L(T)]
```

The corresponding prune must use its reciprocal. The target-density ratio still includes the existing integrated likelihood and depth-prior terms. As in the existing sampler, cancellation of the conditional split-rule density assumes that its prior and proposal match; this PR does not change that prior.

Concrete examples:

1. Minimum leaf size 5, a root split into a constant left child of size 5 and a varying right child of size 15: the old acceptance code predicts reverse prune probability 1, while actual dispatch uses 0.5.
2. Start with two leaves and grow one: there remains one leaf parent, while the old grow ratio uses two reverse-prune choices.
3. Minimum leaf size 2, a four-observation root split into two children of size 2: the split is legal. Grow at the root and prune in the resulting tree both have probability 1. The original dispatch cannot propose that root split.

### Changes

- Add a proposal-state summary of leaves, leaf parents and size-eligible leaves.
- Use its shared grow/prune probabilities for dispatch and acceptance.
- Compute hypothetical post-move state without changing the live tree, accounting for unaffected leaves and changing leaf-parent membership.
- Use reverse-over-forward log proposal ratios in both directions.
- Permit the equality boundary and retain an undersized root without a tree move.

Grow still selects uniformly among **all** leaves; invalid choices are rejected. Size eligibility is not a promise that a grow succeeds: maximum-depth and constant-feature proposals can still be rejected. Feature selection, cutpoint sampling, likelihoods and depth-prior terms are otherwise unchanged.

### Validation

On this independent branch, all **33 C++ tests pass** on macOS ARM64 with Apple Clang, C++17 and OpenMP disabled (28 existing plus five new tests). The earlier combined extrema-plus-acceptance build passed 36 tests.

Five deterministic C++ tests cover proposed versus actual whole-tree state, forward/reverse ratios, unaffected leaves, leaf-parent replacement, equality at the size cutoff, root probabilities after node deletion, and undersized-root handling. They use the real tree and tracker classes.

In supplementary one-feature checks with the extrema correction present in both versions, exact transition matrices were enumerated for 15, 6 and 23 valid trees (4/min1, 6/min2 and 8/min2 observations). The original acceptance formulas violate
detailed balance; corrected matrices preserve the target to approximately 1e-16. These calculations integrate unit-width intervals between integer covariates under the conditional uniform cutpoint prior, with alpha=0.6, beta=2, zero outcomes, and unit Gaussian leaf-prior and observation variances.

A direct C++ sampler check on the four-observation example, with 10,000 burn-in and 500,000 retained iterations (seed 20260907), gives:

| Leaves | Exact posterior | Old acceptance logic | Corrected logic |
| ---: | ---: | ---: | ---: |
| 1 | 50.183% | 42.630% | 50.386% |
| 2 | 42.176% | 54.351% | 42.036% |
| 3 | 7.196% | 3.020% | 7.137% |
| 4 | 0.446% | 0.000% | 0.441% |
