### PR TITLE
Fix NaN ordering in GFR feature presorting

### DIFF
--- a/include/stochtree/partition_tracker.h
+++ b/include/stochtree/partition_tracker.h
@@ -31,6 +31,7 @@
 #include <stochtree/openmp_utils.h>
 #include <stochtree/tree.h>
 
+#include <cmath>
 #include <numeric>
 
 namespace StochTree {
@@ -495,10 +496,16 @@ class FeaturePresortRoot {
     }
     std::iota(feature_sort_indices_.begin(), feature_sort_indices_.end(), 0);
 
-    // Define a custom comparator to be used with stable_sort:
-    // For every two indices l and r store as elements of `data_sort_indices_`, 
-    // compare them for sorting purposes by indexing the covariate's raw data with both l and r
-    auto comp_op = [&](size_t const &l, size_t const &r) { return std::less<double>{}(covariates(l, feature_index_), covariates(r, feature_index_)); };
+    // Ordinary floating-point less-than is not a strict weak ordering with NaNs.
+    // Sort NaNs last, consistent with numeric splits routing them right, while
+    // stable_sort preserves the input order of equal values (including NaNs).
+    auto comp_op = [&](size_t const &l, size_t const &r) {
+      const double left_value = covariates(l, feature_index_);
+      const double right_value = covariates(r, feature_index_);
+      if (std::isnan(left_value)) return false;
+      if (std::isnan(right_value)) return true;
+      return left_value < right_value;
+    };
     std::stable_sort(feature_sort_indices_.begin(), feature_sort_indices_.end(), comp_op);
   }
 

--- a/test/cpp/test_sorted_partition_tracker.cpp
+++ b/test/cpp/test_sorted_partition_tracker.cpp
@@ -5,6 +5,8 @@
 #include <stochtree/meta.h>
 #include <stochtree/partition_tracker.h>
 #include <stochtree/tree.h>
+#include <algorithm>
+#include <limits>
 #include <iostream>
 #include <memory>
 
@@ -97,4 +99,52 @@ TEST(SortedNodeSampleTracker, BasicOperations) {
   ASSERT_EQ(sorted_node_sampler_tracker.NodeEnd(4, 1), n);
   expected_result = {3,0,7,4,5};
   ASSERT_EQ(sorted_node_sampler_tracker.NodeIndices(4, 1), expected_result);
+}
+
+// Exercise the production presort through its public partition view.
+TEST(FeaturePresortRoot, MissingValuesSortLastAcrossPermutations) {
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const std::vector<double> values{-1.0, 0.0, 1.0, nan, nan, 1.0};
+  std::vector<int> permutation{0, 1, 2, 3, 4, 5};
+  do {
+    Eigen::MatrixXd covariates(6, 1);
+    for (int i = 0; i < 6; ++i) covariates(i, 0) = values[permutation[i]];
+    // Construct expected order independently; preserve ties and NaN order.
+    std::vector<StochTree::data_size_t> expected;
+    for (double value : {-1.0, 0.0, 1.0}) {
+      for (int i = 0; i < 6; ++i) {
+        if (covariates(i, 0) == value) expected.push_back(i);
+      }
+    }
+    for (int i = 0; i < 6; ++i) {
+      if (std::isnan(covariates(i, 0))) expected.push_back(i);
+    }
+    StochTree::FeaturePresortRoot root(covariates, 0, StochTree::FeatureType::kNumeric);
+    StochTree::FeaturePresortPartition partition(&root, covariates, 0, StochTree::FeatureType::kNumeric);
+    ASSERT_EQ(partition.NodeIndices(0), expected);
+    // The scored sorted prefix must agree with numeric routing (NaNs go right).
+    partition.SplitFeatureNumeric(covariates, 0, 0, 0.0);
+    ASSERT_EQ(partition.NodeIndices(1), (std::vector<StochTree::data_size_t>{expected[0], expected[1]}));
+    ASSERT_EQ(partition.NodeIndices(2), (std::vector<StochTree::data_size_t>{expected[2], expected[3], expected[4], expected[5]}));
+  } while (std::next_permutation(permutation.begin(), permutation.end()));
+}
+
+TEST(FeaturePresortRoot, NonMissingOrderAndStableTiesArePreserved) {
+  const double inf = std::numeric_limits<double>::infinity();
+  Eigen::MatrixXd covariates(8, 1);
+  covariates << 2.0, -0.0, inf, -2.0, 2.0, -inf, 0.0, -2.0;
+  StochTree::FeaturePresortRoot root(covariates, 0, StochTree::FeatureType::kNumeric);
+  StochTree::FeaturePresortPartition partition(&root, covariates, 0, StochTree::FeatureType::kNumeric);
+  EXPECT_EQ(partition.NodeIndices(0), (std::vector<StochTree::data_size_t>{5, 3, 7, 1, 6, 0, 4, 2}));
+}
+
+TEST(FeaturePresortRoot, EmptySingletonAndAllMissingFeatures) {
+  for (int n : {0, 1, 5}) {
+    Eigen::MatrixXd covariates = Eigen::MatrixXd::Constant(n, 1, std::numeric_limits<double>::quiet_NaN());
+    StochTree::FeaturePresortRoot root(covariates, 0, StochTree::FeatureType::kNumeric);
+    StochTree::FeaturePresortPartition partition(&root, covariates, 0, StochTree::FeatureType::kNumeric);
+    std::vector<StochTree::data_size_t> expected(n);
+    std::iota(expected.begin(), expected.end(), 0);
+    EXPECT_EQ(partition.NodeIndices(0), expected);
+  }
 }


### PR DESCRIPTION
Sorry, here's one more. All came from investigating the same crashes, and with these three fixes on my local fork, my project is now running successfully!

`FeaturePresortRoot::ArgsortRoot()` currently passes ordinary floating-point less-than to `std::stable_sort`. With unequal non-NaN values and NaNs, this does not provide a strict weak ordering: `0` and NaN compare equivalent, and NaN and `1` compare equivalent, but `0` and `1` do not. Presorted rows can consequently leave NaNs interleaved with nonmissing values or leave nonmissing values out of order. GFR relies on these sorted rows when scoring candidate splits, while numeric partitioning routes NaNs right because `NaN <= threshold` is false. A malformed sorted prefix can therefore disagree with actual routing.

This change sorts non-NaNs ascending and NaNs last, retaining stable order for equal values and for NaNs. It preserves the existing comparator behavior for inputs without NaNs, including infinities and signed-zero ties. It does not introduce a learned missing direction or a new missing-data modeling strategy. The change is independent of the MCMC extrema and acceptance fixes.

Three C++ regression tests cover all 720 index permutations of six observations with two NaNs and a finite tie, agreement between the sorted prefix and numeric partitioning, nonmissing order/stability, and empty/singleton/all-NaN inputs. The mixed-data test fails against the unmodified upstream header and passes with this change. The full C++ suite passes all 31 tests. A standalone six-observation C++ reproducer exercising the actual presort is included in the accompanying submission materials.

The issue was discovered while investigating native crashes during GFR on numeric predictors with missing values. In separate R-0.4.5 diagnostics, this comparator repair alone eliminated two previously reproduced crashes; patched AddressSanitizer checks also passed. The small regression test targets the ordering defect rather than promising a portable native crash reproducer. Missing-data fits can change even at the same seed. 